### PR TITLE
Add sponsor link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: RDM3DC
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Adaptive Compression Suite (ACS)
+[![Sponsor](https://img.shields.io/badge/Sponsor-RDM3DC-ff69b4)](https://github.com/sponsors/RDM3DC)
 
 A single repo with **three** distinct compression methods we've developed:
 


### PR DESCRIPTION
## Summary
- add GitHub Sponsors badge pointing to RDM3DC
- include funding configuration for Sponsor button

## Testing
- ⚠️ `pip install -e .` (missing setuptools)
- ⚠️ `pytest` (ModuleNotFoundError: atc, numpy)


------
https://chatgpt.com/codex/tasks/task_e_68b8e5ddf004832f9e3e9574d06c2819